### PR TITLE
Fix theme container check

### DIFF
--- a/src/util/theme-hack.ts
+++ b/src/util/theme-hack.ts
@@ -4,13 +4,16 @@ export const themeHack = `(function(){
   // Qwik initializes. It prevents flash of unstyled content (FOUC) by applying
   // the theme class from localStorage as early as possible.
   if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-    function ensureTheme(){
-      if(!document.querySelector(".theme-container")){
-        requestAnimationFrame(ensureTheme)
+    function ensureTheme() {
+      const themeContainer = document.querySelector(".theme-container");
+      if (!themeContainer) {
+        requestAnimationFrame(ensureTheme);
+        return;
       }
-      themeToEnsure=localStorage.getItem("theme")||"";
-      if(!themeToEnsure) return;
-      document.querySelector(".theme-container").classList.add(themeToEnsure)
+      const themeToEnsure = localStorage.getItem("theme") || "";
+      if (themeToEnsure) {
+        themeContainer.classList.add(themeToEnsure);
+      }
     }
     requestAnimationFrame(ensureTheme);
   }


### PR DESCRIPTION
## Summary
- update util to ensure theme container is available before applying theme

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684000e5b6308320b6e0e515c3549a46