### PR TITLE
Fix typo in root comment

### DIFF
--- a/src/root.tsx
+++ b/src/root.tsx
@@ -17,7 +17,7 @@ export default component$(() => {
    * The root of a QwikCity site always start with the <QwikCityProvider> component,
    * immediately followed by the document's <head> and <body>.
    *
-   * Dont remove the `<head>` and `<body>` elements.
+   * Don't remove the `<head>` and `<body>` elements.
    */
   useStyles$(reset);
   useStyles$(variables);


### PR DESCRIPTION
## Summary
- correct "Dont" to "Don't" in root component comment

## Testing
- `npx vitest` *(fails: interactive watch mode so aborted; tests pass before exit)*

------
https://chatgpt.com/codex/tasks/task_e_684000be54948320bc47dbdf48ccc8a4