### PR TITLE
Fix vitest CI script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install modules
         run: npm ci
       - name: Run tests
-        run: npm test
+        run: npm run test:ci
       - name: Build application
         run: npm run build
       - name: Deploy to S3

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "preview": "qwik build preview && vite preview --open",
     "start": "vite --open --mode ssr",
     "test": "vitest",
+    "test:ci": "vitest run",
     "test:coverage": "vitest run --coverage",
     "qwik": "qwik"
   },


### PR DESCRIPTION
## Summary
- add `test:ci` script to run vitest once
- update GitHub workflow to use `npm run test:ci`

## Testing
- `npm run lint`
- `npm run fmt.check`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_684003abc41c8320a5bb5a0e02293d82