### PR TITLE
Disable lockfile-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     rebase-strategy: "auto"
     allow:
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:lockfile-only"]
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary
- prevent Dependabot from submitting lockfile-only PRs

## Testing
- `npm ci`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_6840090843088320bf7fb93ac36bcd5f