### PR TITLE
Update dependabot config for direct deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     rebase-strategy: "auto"
     allow:
       - dependency-type: "direct"
+    versioning-strategy: increase
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary
- ensure dependabot bumps the manifest when updating direct dependencies

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68428b8dd1808320bc8c44a4ccf42671