### PR TITLE
Add root and posts layout tests

### DIFF
--- a/src/root.test.tsx
+++ b/src/root.test.tsx
@@ -1,0 +1,25 @@
+import { vi, describe, expect, it } from "vitest";
+
+vi.mock("@builder.io/qwik-city", () => ({
+  QwikCityProvider: (props: any) => <div>{props.children}</div>,
+  RouterOutlet: () => <div>router-outlet</div>,
+  ServiceWorkerRegister: () => <service-worker-register />,
+  useDocumentHead: () => ({ title: "t", meta: [], links: [], styles: [] }),
+  useLocation: () => ({ url: { href: "https://example.com" } }),
+}));
+
+import Root from "./root";
+import { createDOM } from "../vitest.setup";
+
+describe("root", () => {
+  it("renders key scripts", async () => {
+    const { render, screen } = await createDOM();
+    await render(<Root />);
+
+    const bodyScripts = Array.from(screen.querySelectorAll("body script"));
+    const themeScript = bodyScripts.find((s) => s.textContent?.includes("ensureTheme"));
+    expect(themeScript?.textContent).toContain("ensureTheme");
+
+    expect(screen.outerHTML).toContain("service-worker-register");
+  });
+});

--- a/src/routes/(posts)/layout.test.ts
+++ b/src/routes/(posts)/layout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { head } from "./layout";
+
+describe("posts layout head", () => {
+  it("generates meta tags", () => {
+    const result = head({
+      head: {
+        title: "My Post",
+        meta: [{ name: "description", content: "awesome" }],
+        frontmatter: { permalink: "/my-post" },
+      },
+    } as any);
+
+    const meta = result.meta;
+    const find = (attr: string, value: string) =>
+      meta.find((m: any) => m[attr] === value);
+
+    expect(find("name", "twitter:title").content).toBe("My Post");
+    expect(find("property", "og:url").content).toBe(
+      "https://doganozturk.dev/my-post",
+    );
+    expect(find("name", "twitter:image").content).toContain("avatar.jpg");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,15 +1,16 @@
 import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { qwikVite } from "@builder.io/qwik/optimizer";
+import { qwikCity } from "@builder.io/qwik-city/vite";
 
 export default defineConfig({
-  plugins: [qwikVite(), tsconfigPaths() as any],
+  plugins: [qwikCity(), qwikVite(), tsconfigPaths() as any],
   test: {
     globals: true,
     environment: "node",
     coverage: {
       reporter: ["text", "json", "html"],
-      include: ["src/components", "src/util"],
+      include: ["src/components", "src/util", "src/routes", "src/root.tsx"],
     },
     setupFiles: ["./vitest.setup.tsx"],
     deps: {


### PR DESCRIPTION
## Summary
- enable qwikCity plugin in test config so MDX transforms work
- test root component for essential scripts
- verify meta tag generation in posts layout

## Testing
- `npm test -- --run --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68434427f33c83209d7f4528e38ade82